### PR TITLE
Update meme-generator.spec.js

### DIFF
--- a/cypress/integration/meme-generator.spec.js
+++ b/cypress/integration/meme-generator.spec.js
@@ -75,6 +75,7 @@ const checkTypedTextIsVisible = () => {
   cy.contains(/^My awesome meme$/).should('be.visible');
 }
 
+// TODO: Testar se a imagem que está sendo feito upload está sendo renderizado na página.
 const memeUpload = () => {
   const fileName = 'meme.jpeg';
   cy.fixture(fileName).then(fileContent => {


### PR DESCRIPTION
Levando em conta uma thread de uma pessoa estudante da turma 6, foi detectado um ponto de falha no requisito 2 (O site deve permitir que quem usa faça upload de uma imagem de seu computador.). 

Por exemplo, se o código for feito assim:

```javascript
photoInsert.addEventListener('change', function(event) {
   memeImage.src = './imgs/meme1.png'; //usei essa URL relativa aqui como referência mas poderia ser qualquer outra.
});
```

O teste passa. Então não valida se foi feito de fato um upload, e sim que ao fazer um upload vai ser exibida uma imagem.  Fica aqui o PR aberto para refatorar esse teste.
